### PR TITLE
fix: bring back arcane shaft without the partial model registration crashes

### DIFF
--- a/src/main/java/net/mcreator/ars_technica/ArsTechnicaMod.java
+++ b/src/main/java/net/mcreator/ars_technica/ArsTechnicaMod.java
@@ -8,6 +8,7 @@ import com.simibubi.create.content.kinetics.BlockStressDefaults;
 import com.simibubi.create.content.kinetics.BlockStressValues;
 import com.simibubi.create.foundation.utility.Couple;
 import com.simibubi.create.foundation.utility.RegisteredObjects;
+import net.mcreator.ars_technica.client.AllPartialModels;
 import net.mcreator.ars_technica.common.items.equipment.SpyMonocleCurioRenderer;
 import net.mcreator.ars_technica.common.kinetics.CustomStressValueProvider;
 import net.mcreator.ars_technica.mixin.BasicSpellTurretMixin;
@@ -72,6 +73,7 @@ public class ArsTechnicaMod {
 		bus.addListener(this::setup);
 
 		DistExecutor.unsafeCallWhenOn(Dist.CLIENT, () -> () -> {
+			AllPartialModels.init();
 			bus.addListener(this::doClientStuff);
 			return new Object();
 		});
@@ -98,7 +100,7 @@ public class ArsTechnicaMod {
 	}
 
 	public void clientSetup(final FMLClientSetupEvent event) {
-		// FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientHandler::init);
+		FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientHandler::init);
 	}
 
 	private static final String PROTOCOL_VERSION = "1";

--- a/src/main/java/net/mcreator/ars_technica/client/AllPartialModels.java
+++ b/src/main/java/net/mcreator/ars_technica/client/AllPartialModels.java
@@ -3,16 +3,11 @@ package net.mcreator.ars_technica.client;
 import com.jozufozu.flywheel.core.PartialModel;
 import net.mcreator.ars_technica.ArsTechnicaMod;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.client.event.ModelEvent;
 
 public class AllPartialModels {
-    public static PartialModel ARCANE_SHAFT_HALF;
+    public static final PartialModel ARCANE_SHAFT_HALF = new PartialModel(new ResourceLocation(ArsTechnicaMod.MODID, "block/arcane_shaft_half"));
 
     public static void init() {
-        ARCANE_SHAFT_HALF = new PartialModel(new ResourceLocation(ArsTechnicaMod.MODID, "block/arcane_shaft_half"));
-    }
-
-    public static void registerAdditionalModels(ModelEvent.RegisterAdditional event) {
-        event.register(ARCANE_SHAFT_HALF.getLocation());
+    	
     }
 }

--- a/src/main/java/net/mcreator/ars_technica/client/events/ClientHandler.java
+++ b/src/main/java/net/mcreator/ars_technica/client/events/ClientHandler.java
@@ -8,6 +8,7 @@ import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
 import net.mcreator.ars_technica.ArsTechnicaMod;
 
+import net.mcreator.ars_technica.client.AllPartialModels;
 import net.mcreator.ars_technica.client.renderer.entity.ArcaneHammerEntityRenderer;
 import net.mcreator.ars_technica.client.renderer.entity.ArcanePolishEntityRenderer;
 import net.mcreator.ars_technica.client.renderer.entity.ArcanePressEntityRenderer;
@@ -56,6 +57,11 @@ public class ClientHandler {
 
         event.register((stack, color) -> color > 0 ? -1 : colorFromArmor(stack),
                 ItemsRegistry.TECHNOMANCER_LEGGINGS.get());
+    }
+
+    @SubscribeEvent
+    public static void init(final FMLClientSetupEvent event) {
+        AllPartialModels.init();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/mcreator/ars_technica/common/blocks/SourceEngineRenderer.java
+++ b/src/main/java/net/mcreator/ars_technica/common/blocks/SourceEngineRenderer.java
@@ -7,6 +7,7 @@ import com.simibubi.create.content.kinetics.base.KineticBlockEntityRenderer;
 import com.simibubi.create.foundation.render.CachedBufferer;
 import com.simibubi.create.foundation.render.SuperByteBuffer;
 import com.simibubi.create.foundation.utility.AnimationTickHolder;
+import net.mcreator.ars_technica.client.AllPartialModels;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -19,6 +20,11 @@ import org.joml.Quaternionf;
 public class SourceEngineRenderer extends KineticBlockEntityRenderer<SourceEngineBlockEntity> {
     public SourceEngineRenderer(BlockEntityRendererProvider.Context context) {
         super(context);
+    }
+
+    @Override
+    protected SuperByteBuffer getRotatedModel(SourceEngineBlockEntity be, BlockState state) {
+        return CachedBufferer.partialFacing(AllPartialModels.ARCANE_SHAFT_HALF, state);
     }
 
     private float getRadiansAngle(SourceEngineBlockEntity be, final BlockPos pos) {
@@ -36,10 +42,6 @@ public class SourceEngineRenderer extends KineticBlockEntityRenderer<SourceEngin
 
         super.renderSafe(blockEntity, partialTicks, poseStack, bufferSource, light, overlay);
 
-        return;
-
-        // Unfortunately the below is unsafe when used with modernfix mixins
-        /*
         if (blockEntity.isFueled()) {
 
             poseStack.pushPose();
@@ -54,7 +56,7 @@ public class SourceEngineRenderer extends KineticBlockEntityRenderer<SourceEngin
 
             poseStack.popPose();
         }
-        */
+
     }
 
     private Quaternionf getQuaternion(SourceEngineBlockEntity be, float radiansAngle) {


### PR DESCRIPTION
The arcane shaft is back, and it also works with ModernFix's dynamic resources. If there are any issues, just let me know!