### PR TITLE
Fixing recipes from hardcoded Create Brass to Forge Brass Ingot Tag

### DIFF
--- a/src/generated/resources/data/ars_technica/recipes/technomancer_boots.json
+++ b/src/generated/resources/data/ars_technica/recipes/technomancer_boots.json
@@ -16,12 +16,12 @@
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     }
   ],

--- a/src/generated/resources/data/ars_technica/recipes/technomancer_chestplate.json
+++ b/src/generated/resources/data/ars_technica/recipes/technomancer_chestplate.json
@@ -16,12 +16,12 @@
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     }
   ],

--- a/src/generated/resources/data/ars_technica/recipes/technomancer_helmet.json
+++ b/src/generated/resources/data/ars_technica/recipes/technomancer_helmet.json
@@ -16,7 +16,7 @@
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     },
     {

--- a/src/generated/resources/data/ars_technica/recipes/technomancer_leggings.json
+++ b/src/generated/resources/data/ars_technica/recipes/technomancer_leggings.json
@@ -16,12 +16,12 @@
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     },
     {
       "item": {
-        "item": "create:brass_ingot"
+        "item": "forge:ingots/brass"
       }
     }
   ],

--- a/src/generated/resources/data/ars_technica/recipes/transmutation_focus.json
+++ b/src/generated/resources/data/ars_technica/recipes/transmutation_focus.json
@@ -13,7 +13,7 @@
   },
   "pedestalItems": [
     {
-      "item": "create:brass_ingot"
+      "item": "forge:ingots/brass"
     },
     {
       "item": "minecraft:rabbit_foot"

--- a/src/main/resources/data/ars_technica/recipes/source_engine.json
+++ b/src/main/resources/data/ars_technica/recipes/source_engine.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "B": {
-      "item": "create:brass_ingot"
+      "item": "forge:ingots/brass"
     },
     "C": {
       "item": "create:cogwheel"


### PR DESCRIPTION
updates every instance of "create:brass" to "forge:ingots/brass", should solve #15 