### PR TITLE
Add depot interactions

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneHammerEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneHammerEntity.java
@@ -16,6 +16,10 @@ import com.zeroregard.ars_technica.registry.SoundRegistry;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.items.IItemHandler;
 import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.ParticleTypes;
@@ -74,6 +78,7 @@ public class ArcaneHammerEntity extends Entity implements GeoEntity, Colorable {
     private boolean didObliterate = false;
     private boolean isCharging = true;
     private boolean chargeAnimationPlayed = false;
+    private BlockPos boundDepotPos;
 
     private Color color;
     private float yaw;
@@ -144,6 +149,10 @@ public class ArcaneHammerEntity extends Entity implements GeoEntity, Colorable {
         setSize(1.0f + amps * AMPS_SIZE_MULTIPLIER);
         setSpeed(1.0f + amps * AMPS_SPEED_MULTIPLIER);
         this.createdTime = world.getGameTime();
+    }
+
+    public void bindDepot(BlockPos depotPos) {
+        this.boundDepotPos = depotPos;
     }
 
     public ArcaneHammerEntity(EntityType<ArcaneHammerEntity> entityType, Level world) {
@@ -246,6 +255,11 @@ public class ArcaneHammerEntity extends Entity implements GeoEntity, Colorable {
     }
 
     protected void handleItems() {
+        if (boundDepotPos != null) {
+            handleDepotItems();
+            return;
+        }
+        
         List<ItemEntity> itemEntities = world.getEntitiesOfClass(ItemEntity.class, getBoundingBox().inflate(1.0));
         if (itemEntities.isEmpty()) {
             return;
@@ -259,6 +273,70 @@ public class ArcaneHammerEntity extends Entity implements GeoEntity, Colorable {
             sendProcessingParticles(midPoint);
         }
         else {itemEntities.forEach(ItemEntity::discard);
+        }
+    }
+
+    private void handleDepotItems() {
+        if (!processItems) {
+            return;
+        }
+
+        BlockEntity be = world.getBlockEntity(boundDepotPos);
+        if (be == null) {
+            return;
+        }
+
+        BlockState bs = be.getBlockState();
+        IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, boundDepotPos, bs, be, null);
+        if (itemHandler == null) {
+            return;
+        }
+
+        Vec3 hammerPos = getPosition(1.0f);
+        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+            ItemStack stack = itemHandler.getStackInSlot(slot);
+            if (stack.isEmpty()) {
+                continue;
+            }
+
+            var recipe = RecipeHelpers.getCrushingRecipeForItemStack(stack, world);
+            if (recipe.isEmpty()) {
+                continue;
+            }
+
+            int count = stack.getCount();
+            itemHandler.extractItem(slot, count, false);
+
+            List<ItemStack> allResults = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                List<ItemStack> rolledResults = recipe.get().rollResults();
+                for (ItemStack result : rolledResults) {
+                    if (RecipeHelpers.isChanceBased(result, recipe.get())) {
+                        float fortuneMultiplier = 1.0f;
+                        if (spellStats != null) {
+                            int fortuneLevel = spellStats.getBuffCount(AugmentFortune.INSTANCE);
+                            fortuneMultiplier = 1.0f + (0.33f * fortuneLevel);
+                            
+                            if (SpellResolverHelpers.shouldDoubleOutputs(resolver)) {
+                                fortuneMultiplier *= 2.0f;
+                            }
+                        }
+                        
+                        int newCount = (int) Math.round(result.getCount() * fortuneMultiplier);
+                        result.setCount(newCount);
+                    }
+                    ItemHelper.addToList(result, allResults);
+                }
+            }
+
+            for (ItemStack result : allResults) {
+                ItemEntity resultEntity = new ItemEntity(world, hammerPos.x, hammerPos.y, hammerPos.z, result);
+                resultEntity.setDeltaMovement(Vec3.ZERO);
+                resultEntity.setPickUpDelay(10);
+                world.addFreshEntity(resultEntity);
+            }
+            
+            sendProcessingParticles(hammerPos);
         }
     }
 

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcanePolishEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcanePolishEntity.java
@@ -50,13 +50,17 @@ public class ArcanePolishEntity extends ArcaneProcessEntity implements GeoEntity
 
 
             if (polishingRecipes.isEmpty()) {
-                processableEntities.remove(currentItem);
-                currentItem = null;
+                if (currentItem != null) {
+                    processableEntities.remove(currentItem);
+                    currentItem = null;
+                }
                 return;
             }
 
-            var currentPos = currentItem.getPosition(1.0f);
-            setPos(currentPos.add(Math.random() / 8f, distanceToItem, Math.random() / 8f));
+            if (currentItem != null) {
+                var currentPos = currentItem.getPosition(1.0f);
+                setPos(currentPos.add(Math.random() / 8f, distanceToItem, Math.random() / 8f));
+            }
 
             RegistryAccess registryAccess = world.registryAccess();
             var firstRecipe = polishingRecipes.getFirst();
@@ -74,7 +78,7 @@ public class ArcanePolishEntity extends ArcaneProcessEntity implements GeoEntity
                     1.5f + (speed / 16));
         }
 
-        if (currentStack.getCount() <= 0) {
+        if (currentStack.getCount() <= 0 && currentItem != null) {
             currentItem = null;
         }
     }
@@ -84,7 +88,11 @@ public class ArcanePolishEntity extends ArcaneProcessEntity implements GeoEntity
         setPos(currentItem.position().add(0, distanceToItem, 0));
     }
 
-
+    @Override
+    protected boolean canProcessStack(ItemStack stack) {
+        var polishingRecipes = SandPaperPolishingRecipe.getMatchingRecipes(world, stack);
+        return !polishingRecipes.isEmpty();
+    }
 
     @Override
     public void registerControllers(AnimatableManager.ControllerRegistrar controllerRegistrar) {

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcanePressEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcanePressEntity.java
@@ -17,7 +17,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 import java.util.List;
 
-public class ArcanePressEntity extends ArcaneProcessEntity implements GeoEntity, Colorable {
+public class ArcanePressEntity extends ArcaneProcessEntity implements GeoEntity {
 
 
     public ArcanePressEntity(Vec3 position, Level world, int maxAmountToPress, float speed, Color color, List<ItemEntity> pressableEntities) {
@@ -39,13 +39,17 @@ public class ArcanePressEntity extends ArcaneProcessEntity implements GeoEntity,
             var pressingRecipe = RecipeHelpers.getPressingRecipeForItemStack(currentStack, world);
 
             if (pressingRecipe.isEmpty()) {
-                processableEntities.remove(currentItem);
-                currentItem = null;
+                if (currentItem != null) {
+                    processableEntities.remove(currentItem);
+                    currentItem = null;
+                }
                 return;
             }
 
-            var currentPos = currentItem.getPosition(1.0f);
-            setPos(currentPos.add(0, 1f, 0));
+            if (currentItem != null) {
+                var currentPos = currentItem.getPosition(1.0f);
+                setPos(currentPos.add(0, 1f, 0));
+            }
 
             RegistryAccess registryAccess = world.registryAccess();
             var recipe = pressingRecipe.get().value();
@@ -62,9 +66,15 @@ public class ArcanePressEntity extends ArcaneProcessEntity implements GeoEntity,
                     .75f + (speed / 16));
         }
 
-        if (currentStack.getCount() <= 0) {
+        if (currentStack.getCount() <= 0 && currentItem != null) {
             currentItem = null;
         }
+    }
+
+    @Override
+    protected boolean canProcessStack(ItemStack stack) {
+        var pressingRecipe = RecipeHelpers.getPressingRecipeForItemStack(stack, world);
+        return pressingRecipe.isPresent();
     }
 
     @Override

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
@@ -1,5 +1,6 @@
 package com.zeroregard.ars_technica.entity;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -9,7 +10,11 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.util.Color;
 
@@ -31,6 +36,8 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
     protected int tickCount;
     protected Color color;
     protected Level world;
+    protected BlockPos boundDepotPos;
+    protected int currentDepotSlot = 0;
 
     protected static final EntityDataAccessor<Float> SPEED = SynchedEntityData.defineId(ArcaneProcessEntity.class, EntityDataSerializers.FLOAT);
     protected static final EntityDataAccessor<Integer> COLOR = SynchedEntityData.defineId(ArcaneProcessEntity.class, EntityDataSerializers.INT);
@@ -50,6 +57,14 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
 
     protected void setColor(Color color) {
         this.entityData.set(COLOR, color.getColor());
+    }
+
+    public void bindDepot(BlockPos depotPos) {
+        this.boundDepotPos = depotPos;
+    }
+
+    public boolean isBoundToDepot() {
+        return boundDepotPos != null;
     }
 
     public ArcaneProcessEntity(EntityType<?> entityType, Vec3 position, Level world, int maxToProcess, float speed, Color color, List<ItemEntity> processableEntities) {
@@ -92,21 +107,28 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
     public void tick() {
         super.tick();
 
-        if (currentItem == null || currentItem.isRemoved()) {
-            findNextItem();
-        }
-
-        if ((amountProcessed == maxToProcess || currentItem == null) && !world.isClientSide) {
-            this.discard();
-        }
-
-        handleProcessLogic();
-
-        if (tickCount >= getTicksToReset()) {
-            if(currentItem != null && !currentItem.isRemoved()) {
-                moveToItem();
+        if (isBoundToDepot()) {
+            handleDepotProcessing();
+            if (tickCount >= getTicksToReset()) {
+                tickCount = 0;
             }
-            tickCount = 0;
+        } else {
+            if (currentItem == null || currentItem.isRemoved()) {
+                findNextItem();
+            }
+
+            if ((amountProcessed == maxToProcess || currentItem == null) && !world.isClientSide) {
+                this.discard();
+            }
+
+            handleProcessLogic();
+
+            if (tickCount >= getTicksToReset()) {
+                if(currentItem != null && !currentItem.isRemoved()) {
+                    moveToItem();
+                }
+                tickCount = 0;
+            }
         }
         tickCount++;
     }
@@ -152,6 +174,76 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
         }
     }
 
+    private void handleDepotProcessing() {
+        if (world.isClientSide) {
+            return;
+        }
+
+        if (amountProcessed >= maxToProcess) {
+            this.discard();
+            return;
+        }
+
+        BlockEntity be = world.getBlockEntity(boundDepotPos);
+        if (be == null) {
+            this.discard();
+            return;
+        }
+
+        BlockState bs = be.getBlockState();
+        IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, boundDepotPos, bs, be, null);
+        if (itemHandler == null) {
+            this.discard();
+            return;
+        }
+
+        if (tickCount == getTicksToPress()) {
+            boolean processedAny = false;
+            for (int slot = currentDepotSlot; slot < itemHandler.getSlots(); slot++) {
+                ItemStack stack = itemHandler.getStackInSlot(slot);
+                if (stack.isEmpty()) {
+                    continue;
+                }
+
+                if (canProcessStack(stack)) {
+                    processDepotItem(itemHandler, slot, stack);
+                    currentDepotSlot = slot;
+                    processedAny = true;
+                    break;
+                }
+            }
+
+            if (!processedAny) {
+                this.discard();
+            }
+        }
+    }
+
+    protected void processDepotItem(IItemHandler itemHandler, int slot, ItemStack stack) {
+        ItemStack extracted = itemHandler.extractItem(slot, 1, false);
+        if (extracted.isEmpty()) {
+            return;
+        }
+
+        currentOutput = null;
+        
+        ItemEntity tempEntity = new ItemEntity(world, getX(), getY(), getZ(), extracted);
+        process(tempEntity);
+        tempEntity.discard();
+
+        if (currentOutput != null && !currentOutput.isRemoved()) {
+            ItemStack outputStack = currentOutput.getItem();
+            currentOutput.discard();
+            ItemEntity outputEntity = new ItemEntity(world, getX(), getY(), getZ(), outputStack);
+            outputEntity.setDeltaMovement(Vec3.ZERO);
+            outputEntity.setPickUpDelay(10);
+            world.addFreshEntity(outputEntity);
+            currentOutput = null;
+        }
+    }
+
+    protected abstract boolean canProcessStack(ItemStack stack);
+
     protected abstract void process(ItemEntity item);
 
     @Override
@@ -164,12 +256,27 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
             this.color = new Color(compound.getInt("Color"));
             this.entityData.set(COLOR, this.color.getColor());
         }
+        if (compound.contains("DepotX")) {
+            int x = compound.getInt("DepotX");
+            int y = compound.getInt("DepotY");
+            int z = compound.getInt("DepotZ");
+            this.boundDepotPos = new BlockPos(x, y, z);
+        }
+        if (compound.contains("DepotSlot")) {
+            this.currentDepotSlot = compound.getInt("DepotSlot");
+        }
     }
 
     @Override
     protected void addAdditionalSaveData(CompoundTag compound) {
         compound.putFloat("Speed", this.speed);
         compound.putInt("Color", this.color.getColor());
+        if (this.boundDepotPos != null) {
+            compound.putInt("DepotX", this.boundDepotPos.getX());
+            compound.putInt("DepotY", this.boundDepotPos.getY());
+            compound.putInt("DepotZ", this.boundDepotPos.getZ());
+        }
+        compound.putInt("DepotSlot", this.currentDepotSlot);
     }
 
 

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneWhirlEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneWhirlEntity.java
@@ -5,6 +5,7 @@ import com.simibubi.create.content.kinetics.fan.AirCurrent;
 import com.simibubi.create.content.kinetics.fan.IAirCurrentSource;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+import com.zeroregard.ars_technica.ArsTechnica;
 import com.zeroregard.ars_technica.client.ClientHandler;
 import com.zeroregard.ars_technica.helpers.SpellResolverHelpers;
 import com.zeroregard.ars_technica.kinetics.WhirlCurrent;

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneWhirlEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneWhirlEntity.java
@@ -37,6 +37,8 @@ public class ArcaneWhirlEntity extends Entity implements IAirCurrentSource, GeoE
     private WhirlCurrent current;
     private final SpellResolver spellResolver;
     private boolean soundPlaying;
+    private boolean swirlPhysicsEnabled = true;
+    private BlockPos boundDepotPos;
 
     private static final EntityDataAccessor<String> PROCESSOR_TYPE = SynchedEntityData.defineId(ArcaneWhirlEntity.class, EntityDataSerializers.STRING);
     private static final EntityDataAccessor<Float> SPEED = SynchedEntityData.defineId(ArcaneWhirlEntity.class, EntityDataSerializers.FLOAT);
@@ -58,6 +60,14 @@ public class ArcaneWhirlEntity extends Entity implements IAirCurrentSource, GeoE
 
     public FanProcessingType getProcessor() {
         return processor;
+    }
+
+    public boolean isSwirlPhysicsEnabled() {
+        return swirlPhysicsEnabled;
+    }
+
+    public BlockPos getBoundDepotPos() {
+        return boundDepotPos;
     }
 
     public ArcaneWhirlEntity(EntityType<? extends ArcaneWhirlEntity> entityType, Level world) {
@@ -119,6 +129,11 @@ public class ArcaneWhirlEntity extends Entity implements IAirCurrentSource, GeoE
             return "SPLASHING";
         }
         return "NONE";
+    }
+
+    public void bindDepot(BlockPos depotPos) {
+        this.boundDepotPos = depotPos;
+        this.swirlPhysicsEnabled = false;
     }
 
     private void handleWhirlwindEffect() {
@@ -183,6 +198,15 @@ public class ArcaneWhirlEntity extends Entity implements IAirCurrentSource, GeoE
             String processorType = compound.getString("ProcessorType");
             setProcessor(AllFanProcessingTypes.parseLegacy(processorType));
         }
+        if (compound.contains("SwirlPhysics")) {
+            this.swirlPhysicsEnabled = compound.getBoolean("SwirlPhysics");
+        }
+        if (compound.contains("DepotX")) {
+            int x = compound.getInt("DepotX");
+            int y = compound.getInt("DepotY");
+            int z = compound.getInt("DepotZ");
+            this.boundDepotPos = new BlockPos(x, y, z);
+        }
     }
 
     @Override
@@ -192,6 +216,12 @@ public class ArcaneWhirlEntity extends Entity implements IAirCurrentSource, GeoE
         compound.putFloat("Speed", this.speed);
         if (this.processor != null) {
             compound.putString("ProcessorType", getProcessorLegacyId(this.processor));
+        }
+        compound.putBoolean("SwirlPhysics", this.swirlPhysicsEnabled);
+        if (this.boundDepotPos != null) {
+            compound.putInt("DepotX", this.boundDepotPos.getX());
+            compound.putInt("DepotY", this.boundDepotPos.getY());
+            compound.putInt("DepotZ", this.boundDepotPos.getZ());
         }
     }
 

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectObliterate.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectObliterate.java
@@ -4,11 +4,14 @@ import com.hollingsworth.arsnouveau.api.spell.*;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
+import com.simibubi.create.content.logistics.depot.DepotBlock;
 import com.zeroregard.ars_technica.entity.ArcaneHammerEntity;
+import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
@@ -36,17 +39,25 @@ public class EffectObliterate extends AbstractEffect {
     }
 
     public void onResolveBlock(BlockHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        var position = rayTraceResult.getBlockPos().getCenter().add(0, 0.5, 0);
-        resolve(null, position, world, shooter, spellStats, spellContext, resolver);
+        BlockPos blockPos = rayTraceResult.getBlockPos();
+        BlockState state = world.getBlockState(blockPos);
+        var position = blockPos.getCenter().add(0, 0.5, 0);
+        
+        ArcaneHammerEntity hammer = resolve(null, position, world, shooter, spellStats, spellContext, resolver);
+        
+        if (state.getBlock() instanceof DepotBlock && hammer != null) {
+            hammer.bindDepot(blockPos);
+        }
     }
 
-    private void resolve(@Nullable Entity target, Vec3 position, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+    private ArcaneHammerEntity resolve(@Nullable Entity target, Vec3 position, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         var color = new Color(spellContext.getColors().getColor());
         SpellContext newContext = spellContext.makeChildContext();
         spellContext.setCanceled(true);
         ArcaneHammerEntity arcaneHammerEntity = new ArcaneHammerEntity(target, position, world, shooter, color, resolver.getNewResolver(newContext), spellStats);
         setYaw(position, shooter, arcaneHammerEntity);
         world.addFreshEntity(arcaneHammerEntity);
+        return arcaneHammerEntity;
     }
 
     private void setYaw(Vec3 position, @NotNull LivingEntity shooter, ArcaneHammerEntity arcaneHammerEntity) {

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectPolish.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectPolish.java
@@ -3,15 +3,20 @@ package com.zeroregard.ars_technica.glyphs;
 import com.hollingsworth.arsnouveau.api.spell.*;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.simibubi.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
+import com.simibubi.create.content.logistics.depot.DepotBlock;
 import com.zeroregard.ars_technica.entity.ArcanePolishEntity;
 import com.zeroregard.ars_technica.helpers.SpellResolverHelpers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.util.Color;
 
 import javax.annotation.Nonnull;
@@ -27,6 +32,31 @@ public class EffectPolish extends AbstractItemResolveEffect {
 
     private EffectPolish(ResourceLocation resourceLocation, String description) {
         super(resourceLocation, description);
+    }
+
+    @Override
+    public void onResolve(net.minecraft.world.phys.HitResult rayTraceResult, Level world, @Nullable LivingEntity shooter, 
+                          SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        if (rayTraceResult instanceof BlockHitResult blockHit) {
+            BlockPos blockPos = blockHit.getBlockPos();
+            BlockState state = world.getBlockState(blockPos);
+            
+            if (state.getBlock() instanceof DepotBlock) {
+                boolean hasFocus = SpellResolverHelpers.hasTransmutationFocus(resolver);
+                int aoeBuff = (int)Math.round(spellStats.getAoeMultiplier());
+                int maxAmountToPolish = Math.round(4 * (1 + aoeBuff)) * (hasFocus ? 2 : 1);
+                float speed = hasFocus ? DEFAULT_SPEED * 2.5f : DEFAULT_SPEED;
+                var color = new Color(spellContext.getColors().getColor());
+                
+                Vec3 spawnPos = Vec3.atCenterOf(blockPos).add(0, 0.5, 0);
+                ArcanePolishEntity arcanePolishEntity = new ArcanePolishEntity(spawnPos, world, maxAmountToPolish, speed, color, Collections.emptyList());
+                arcanePolishEntity.bindDepot(blockPos);
+                world.addFreshEntity(arcanePolishEntity);
+                return;
+            }
+        }
+        
+        super.onResolve(rayTraceResult, world, shooter, spellStats, spellContext, resolver);
     }
 
     @Override

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectPress.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectPress.java
@@ -3,16 +3,21 @@ package com.zeroregard.ars_technica.glyphs;
 import com.hollingsworth.arsnouveau.api.spell.*;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.simibubi.create.content.kinetics.press.PressingRecipe;
+import com.simibubi.create.content.logistics.depot.DepotBlock;
 import com.zeroregard.ars_technica.entity.ArcanePressEntity;
 import com.zeroregard.ars_technica.helpers.RecipeHelpers;
 import com.zeroregard.ars_technica.helpers.SpellResolverHelpers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.util.Color;
 
 import javax.annotation.Nonnull;
@@ -27,6 +32,31 @@ public class EffectPress extends AbstractItemResolveEffect {
 
     private EffectPress(ResourceLocation resourceLocation, String description) {
         super(resourceLocation, description);
+    }
+
+    @Override
+    public void onResolve(net.minecraft.world.phys.HitResult rayTraceResult, Level world, @Nullable LivingEntity shooter, 
+                          SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        if (rayTraceResult instanceof BlockHitResult blockHit) {
+            BlockPos blockPos = blockHit.getBlockPos();
+            BlockState state = world.getBlockState(blockPos);
+            
+            if (state.getBlock() instanceof DepotBlock) {
+                boolean hasFocus = SpellResolverHelpers.hasTransmutationFocus(resolver);
+                int aoeBuff = (int)Math.round(spellStats.getAoeMultiplier());
+                int maxAmountToPress = Math.round(4 * (1 + aoeBuff)) * (hasFocus ? 2 : 1);
+                float speed = hasFocus ? DEFAULT_SPEED * 2.5f : DEFAULT_SPEED;
+                var color = new Color(spellContext.getColors().getColor());
+                
+                Vec3 spawnPos = Vec3.atCenterOf(blockPos).add(0, 1.0, 0);
+                ArcanePressEntity arcanePressEntity = new ArcanePressEntity(spawnPos, world, maxAmountToPress, speed, color, Collections.emptyList());
+                arcanePressEntity.bindDepot(blockPos);
+                world.addFreshEntity(arcanePressEntity);
+                return;
+            }
+        }
+        
+        super.onResolve(rayTraceResult, world, shooter, spellStats, spellContext, resolver);
     }
 
     @Override

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
@@ -12,22 +12,17 @@ import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
 import com.simibubi.create.content.logistics.depot.DepotBlock;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
-import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -63,11 +58,15 @@ public class EffectWhirl extends AbstractEffect {
 
         BlockPos blockPos = rayTraceResult.getBlockPos();
         BlockState state = world.getBlockState(blockPos);
+        boolean boundToDepot = false;
         if (state.getBlock() instanceof DepotBlock) {
-            handleDepotExtraction(serverWorld, blockPos, adjustedPosition);
+            boundToDepot = true;
         }
 
-        resolve(adjustedPosition, serverWorld, shooter, spellStats, spellContext, resolver);
+        ArcaneWhirlEntity whirl = resolve(adjustedPosition, serverWorld, shooter, spellStats, spellContext, resolver);
+        if (boundToDepot && whirl != null) {
+            whirl.bindDepot(blockPos);
+        }
     }
 
     private Vec3 getAdjustedPosition(BlockHitResult rayTraceResult) {
@@ -92,7 +91,7 @@ public class EffectWhirl extends AbstractEffect {
         }
     }
 
-    protected void resolve(Vec3 position, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+    protected ArcaneWhirlEntity resolve(Vec3 position, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
 
         float aoeAmplifier = (float)spellStats.getAoeMultiplier();
         double durationAmplifier = spellStats.getDurationMultiplier();
@@ -120,25 +119,7 @@ public class EffectWhirl extends AbstractEffect {
 
         ArcaneWhirlEntity whirl = new ArcaneWhirlEntity(world, position, DEFAULT_RADIUS + aoeAmplifier * 0.33f, DEFAULT_DURATION + extraDurationTicks, processingType, resolver);
         world.addFreshEntity(whirl);
-    }
-
-    private void handleDepotExtraction(ServerLevel world, BlockPos pos, Vec3 dropPosition) {
-        BlockEntity be = world.getBlockEntity(pos);
-        if (be == null) return;
-        BlockState bs = be.getBlockState();
-        IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, pos, bs, be, null);
-        if (itemHandler == null) return;
-
-        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
-            ItemStack inSlot = itemHandler.getStackInSlot(slot);
-            if (inSlot.isEmpty()) continue;
-            int extractAmount = inSlot.getCount();
-            if (extractAmount <= 0) continue;
-            ItemStack extracted = itemHandler.extractItem(slot, extractAmount, false);
-            if (extracted.isEmpty()) continue;
-            ItemEntity itemEntity = new ItemEntity(world, dropPosition.x, dropPosition.y, dropPosition.z, extracted);
-            world.addFreshEntity(itemEntity);
-        }
+        return whirl;
     }
 
     @Override

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
@@ -11,6 +11,7 @@ import com.hollingsworth.arsnouveau.common.spell.effect.EffectSmelt;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
 import com.simibubi.create.content.logistics.depot.DepotBlock;
+import com.zeroregard.ars_technica.ArsTechnica;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -54,16 +55,23 @@ public class EffectWhirl extends AbstractEffect {
     @Override
     public void onResolveBlock(BlockHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         if (!(world instanceof ServerLevel serverWorld)) return;
-        Vec3 adjustedPosition = getAdjustedPosition(rayTraceResult);
-
+        
         BlockPos blockPos = rayTraceResult.getBlockPos();
         BlockState state = world.getBlockState(blockPos);
+
         boolean boundToDepot = false;
         if (state.getBlock() instanceof DepotBlock) {
             boundToDepot = true;
         }
+        
+        Vec3 adjustedPosition;
+        if (boundToDepot) {
+            adjustedPosition = Vec3.atCenterOf(blockPos).add(0, 0.5, 0);
+        } else {
+            adjustedPosition = getAdjustedPosition(rayTraceResult);
+        }
 
-        ArcaneWhirlEntity whirl = resolve(adjustedPosition, serverWorld, shooter, spellStats, spellContext, resolver);
+        ArcaneWhirlEntity whirl = resolve(adjustedPosition, serverWorld, shooter, spellStats, spellContext, resolver);      
         if (boundToDepot && whirl != null) {
             whirl.bindDepot(blockPos);
         }

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
@@ -10,17 +10,24 @@ import com.hollingsworth.arsnouveau.common.spell.effect.EffectHex;
 import com.hollingsworth.arsnouveau.common.spell.effect.EffectSmelt;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+import com.simibubi.create.content.logistics.depot.DepotBlock;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -53,6 +60,13 @@ public class EffectWhirl extends AbstractEffect {
     public void onResolveBlock(BlockHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         if (!(world instanceof ServerLevel serverWorld)) return;
         Vec3 adjustedPosition = getAdjustedPosition(rayTraceResult);
+
+        BlockPos blockPos = rayTraceResult.getBlockPos();
+        BlockState state = world.getBlockState(blockPos);
+        if (state.getBlock() instanceof DepotBlock) {
+            handleDepotExtraction(serverWorld, blockPos, adjustedPosition);
+        }
+
         resolve(adjustedPosition, serverWorld, shooter, spellStats, spellContext, resolver);
     }
 
@@ -106,6 +120,25 @@ public class EffectWhirl extends AbstractEffect {
 
         ArcaneWhirlEntity whirl = new ArcaneWhirlEntity(world, position, DEFAULT_RADIUS + aoeAmplifier * 0.33f, DEFAULT_DURATION + extraDurationTicks, processingType, resolver);
         world.addFreshEntity(whirl);
+    }
+
+    private void handleDepotExtraction(ServerLevel world, BlockPos pos, Vec3 dropPosition) {
+        BlockEntity be = world.getBlockEntity(pos);
+        if (be == null) return;
+        BlockState bs = be.getBlockState();
+        IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, pos, bs, be, null);
+        if (itemHandler == null) return;
+
+        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+            ItemStack inSlot = itemHandler.getStackInSlot(slot);
+            if (inSlot.isEmpty()) continue;
+            int extractAmount = inSlot.getCount();
+            if (extractAmount <= 0) continue;
+            ItemStack extracted = itemHandler.extractItem(slot, extractAmount, false);
+            if (extracted.isEmpty()) continue;
+            ItemEntity itemEntity = new ItemEntity(world, dropPosition.x, dropPosition.y, dropPosition.z, extracted);
+            world.addFreshEntity(itemEntity);
+        }
     }
 
     @Override

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectWhirl.java
@@ -11,7 +11,6 @@ import com.hollingsworth.arsnouveau.common.spell.effect.EffectSmelt;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
 import com.simibubi.create.content.logistics.depot.DepotBlock;
-import com.zeroregard.ars_technica.ArsTechnica;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
+++ b/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
@@ -8,6 +8,7 @@ import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
 import com.zeroregard.ars_technica.network.ParticleEffectPacket;
 import com.zeroregard.ars_technica.registry.ParticleRegistry;
 import com.zeroregard.ars_technica.registry.SoundRegistry;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -16,12 +17,19 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.items.IItemHandler;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.UUID;
 
 public class WhirlCurrent {
@@ -33,6 +41,7 @@ public class WhirlCurrent {
     private int tickCount = 0;
     private double tangentialFactor = 0.25;
     private double pullFactor = 3.0;
+    private final Map<Integer, CompoundTag> depotSlotProcessing = new HashMap<>();
 
     public WhirlCurrent(ArcaneWhirlEntity source) {
         this.source = source;
@@ -51,6 +60,11 @@ public class WhirlCurrent {
     }
 
     protected void tickAffectedEntities(Level world, SpellResolver whirlOwner) {
+        if (!source.isSwirlPhysicsEnabled() && source.getBoundDepotPos() != null) {
+            tickDepotProcessing(world, whirlOwner);
+            return;
+        }
+
         affectedEntities = world.getEntitiesOfClass(ItemEntity.class, bounds);
         if (tickCount % 4 == 0) {
             sendWhirlParticles(world, source.getProcessor());
@@ -62,7 +76,9 @@ public class WhirlCurrent {
                 continue;
             }
 
-            moveItem(entity);
+            if (source.isSwirlPhysicsEnabled()) {
+                moveItem(entity);
+            }
 
             FanProcessingType processingType = source.getProcessor();
 
@@ -86,6 +102,64 @@ public class WhirlCurrent {
                 }
             }
         }
+    }
+
+    private void tickDepotProcessing(Level world, SpellResolver whirlOwner) {
+        BlockPos depotPos = source.getBoundDepotPos();
+        if (depotPos == null) return;
+
+        BlockEntity be = world.getBlockEntity(depotPos);
+        if (be == null) return;
+        BlockState bs = be.getBlockState();
+
+        IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, depotPos, bs, be, null);
+        if (itemHandler == null) return;
+
+        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+            ItemStack stack = itemHandler.getStackInSlot(slot);
+            if (stack.isEmpty()) continue;
+
+            int extractAmount = Math.min(stack.getCount(), 1);
+            ItemStack extracted = itemHandler.extractItem(slot, extractAmount, true);
+            if (extracted.isEmpty()) continue;
+
+            FanProcessingType processingType = source.getProcessor();
+            if (processingType == null) {
+                return;
+            }
+
+            ItemEntity temp = new ItemEntity(world, source.getX(), source.getY(), source.getZ(), extracted.copy());
+            CompoundTag saved = depotSlotProcessing.get(slot);
+            if (saved != null) {
+                temp.getPersistentData().put("CreateData", saved.copy());
+            }
+            boolean processed = WhirlProcessing.applyProcessing(temp, processingType, world, whirlOwner);
+
+            if (processed) {
+                itemHandler.extractItem(slot, extractAmount, false);
+                ItemStack remaining = temp.getItem();
+                if (!remaining.isEmpty() && !ItemStack.isSameItemSameComponents(remaining, extracted)) {
+                    ItemStack leftover = remaining.copy();
+                    leftover = tryInsertIntoHandler(itemHandler, leftover);
+                    if (!leftover.isEmpty()) {
+                        world.addFreshEntity(new ItemEntity(world, source.getX(), source.getY(), source.getZ(), leftover));
+                    }
+                }
+                depotSlotProcessing.remove(slot);
+            } else {
+                CompoundTag updated = temp.getPersistentData().getCompound("CreateData");
+                depotSlotProcessing.put(slot, updated.copy());
+            }
+            break;
+        }
+    }
+
+    private ItemStack tryInsertIntoHandler(IItemHandler handler, ItemStack stack) {
+        ItemStack toInsert = stack;
+        for (int i = 0; i < handler.getSlots() && !toInsert.isEmpty(); i++) {
+            toInsert = handler.insertItem(i, toInsert, false);
+        }
+        return toInsert;
     }
 
     private void moveItem(Entity entity) {

--- a/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
+++ b/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
@@ -4,7 +4,6 @@ import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
-import com.zeroregard.ars_technica.ArsTechnica;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
 import com.zeroregard.ars_technica.network.ParticleEffectPacket;
 import com.zeroregard.ars_technica.registry.ParticleRegistry;
@@ -31,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import com.simibubi.create.content.logistics.basin.BasinBlockEntity;
 import java.util.UUID;
 
 public class WhirlCurrent {
@@ -62,16 +62,10 @@ public class WhirlCurrent {
 
     protected void tickAffectedEntities(Level world, SpellResolver whirlOwner) {
         if (!source.isSwirlPhysicsEnabled() && source.getBoundDepotPos() != null) {
-            if (tickCount % 20 == 0) {
-                ArsTechnica.LOGGER.info("WhirlCurrent: Taking depot processing path. DepotPos={}", source.getBoundDepotPos());
-            }
             tickDepotProcessing(world, whirlOwner);
             return;
         }
 
-        if (tickCount % 20 == 0) {
-            ArsTechnica.LOGGER.info("WhirlCurrent: Taking normal processing path. swirlPhysics={}, depotPos={}", source.isSwirlPhysicsEnabled(), source.getBoundDepotPos());
-        }
         affectedEntities = world.getEntitiesOfClass(ItemEntity.class, bounds);
         if (tickCount % 4 == 0) {
             sendWhirlParticles(world, source.getProcessor());
@@ -114,49 +108,32 @@ public class WhirlCurrent {
     private void tickDepotProcessing(Level world, SpellResolver whirlOwner) {
         BlockPos depotPos = source.getBoundDepotPos();
         if (depotPos == null) {
-            ArsTechnica.LOGGER.warn("tickDepotProcessing: depotPos is null!");
             return;
         }
 
         BlockEntity be = world.getBlockEntity(depotPos);
         if (be == null) {
-            if (tickCount % 20 == 0) {
-                ArsTechnica.LOGGER.warn("tickDepotProcessing: No block entity at {}", depotPos);
-            }
             return;
         }
         BlockState bs = be.getBlockState();
-        if (tickCount % 20 == 0) {
-            ArsTechnica.LOGGER.info("tickDepotProcessing: Found block entity {} at {}", be, depotPos);
-        }
 
         IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, depotPos, bs, be, null);
         if (itemHandler == null) {
-            if (tickCount % 20 == 0) {
-                ArsTechnica.LOGGER.warn("tickDepotProcessing: No item handler capability for {}", be);
-            }
             return;
-        }
-        if (tickCount % 20 == 0) {
-            ArsTechnica.LOGGER.info("tickDepotProcessing: Got item handler with {} slots", itemHandler.getSlots());
         }
 
         for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
             ItemStack stack = itemHandler.getStackInSlot(slot);
-            if (tickCount % 20 == 0) {
-                ArsTechnica.LOGGER.info("tickDepotProcessing: Slot {}: {}", slot, stack);
-            }
             if (stack.isEmpty()) continue;
 
             int extractAmount = Math.min(stack.getCount(), 1);
             ItemStack extracted = itemHandler.extractItem(slot, extractAmount, true);
-            ArsTechnica.LOGGER.info("tickDepotProcessing: Simulated extraction from slot {}: {}", slot, extracted);
+          
             if (extracted.isEmpty()) continue;
 
             FanProcessingType processingType = source.getProcessor();
-            ArsTechnica.LOGGER.info("tickDepotProcessing: ProcessingType={}", processingType);
+
             if (processingType == null) {
-                ArsTechnica.LOGGER.warn("tickDepotProcessing: No processing type, stopping");
                 return;
             }
 
@@ -167,17 +144,12 @@ public class WhirlCurrent {
                 temp.getPersistentData().put("CreateData", saved.copy());
                 CompoundTag processingTag = saved.getCompound("Processing");
                 int timeLeft = processingTag.getInt("Time");
-                ArsTechnica.LOGGER.info("tickDepotProcessing: Restored processing data for slot {}, timeLeft={}", slot, timeLeft);
-            } else {
-                ArsTechnica.LOGGER.info("tickDepotProcessing: No saved processing data for slot {}, will initialize", slot);
             }
             boolean processed = WhirlProcessing.applyProcessing(temp, processingType, world, whirlOwner);
             CompoundTag afterProcessing = temp.getPersistentData().getCompound("CreateData").getCompound("Processing");
             int timeAfter = afterProcessing.getInt("Time");
-            ArsTechnica.LOGGER.info("tickDepotProcessing: Processing result for slot {}: processed={}, timeAfter={}", slot, processed, timeAfter);
 
             if (processed) {
-                ArsTechnica.LOGGER.info("tickDepotProcessing: Item finished processing! Extracting from depot");
                 itemHandler.extractItem(slot, extractAmount, false);
                 
                 Vec3 itemPosition = new Vec3(source.getX(), source.getY(), source.getZ());
@@ -185,7 +157,6 @@ public class WhirlCurrent {
                 
                 ItemStack primaryResult = temp.getItem();
                 if (!primaryResult.isEmpty()) {
-                    ArsTechnica.LOGGER.info("tickDepotProcessing: Spawning primary result: {}", primaryResult);
                     ItemEntity resultEntity = new ItemEntity(world, source.getX(), source.getY(), source.getZ(), primaryResult);
                     resultEntity.setDeltaMovement(Vec3.ZERO);
                     resultEntity.setPickUpDelay(10);
@@ -203,7 +174,6 @@ public class WhirlCurrent {
                 
                 CompoundTag updated = temp.getPersistentData().getCompound("CreateData");
                 depotSlotProcessing.put(slot, updated.copy());
-                ArsTechnica.LOGGER.info("tickDepotProcessing: Item still processing, saved state for slot {}", slot);
             }
             break;
         }

--- a/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
+++ b/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlCurrent.java
@@ -4,6 +4,7 @@ import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
+import com.zeroregard.ars_technica.ArsTechnica;
 import com.zeroregard.ars_technica.entity.ArcaneWhirlEntity;
 import com.zeroregard.ars_technica.network.ParticleEffectPacket;
 import com.zeroregard.ars_technica.registry.ParticleRegistry;
@@ -61,10 +62,16 @@ public class WhirlCurrent {
 
     protected void tickAffectedEntities(Level world, SpellResolver whirlOwner) {
         if (!source.isSwirlPhysicsEnabled() && source.getBoundDepotPos() != null) {
+            if (tickCount % 20 == 0) {
+                ArsTechnica.LOGGER.info("WhirlCurrent: Taking depot processing path. DepotPos={}", source.getBoundDepotPos());
+            }
             tickDepotProcessing(world, whirlOwner);
             return;
         }
 
+        if (tickCount % 20 == 0) {
+            ArsTechnica.LOGGER.info("WhirlCurrent: Taking normal processing path. swirlPhysics={}, depotPos={}", source.isSwirlPhysicsEnabled(), source.getBoundDepotPos());
+        }
         affectedEntities = world.getEntitiesOfClass(ItemEntity.class, bounds);
         if (tickCount % 4 == 0) {
             sendWhirlParticles(world, source.getProcessor());
@@ -106,61 +113,102 @@ public class WhirlCurrent {
 
     private void tickDepotProcessing(Level world, SpellResolver whirlOwner) {
         BlockPos depotPos = source.getBoundDepotPos();
-        if (depotPos == null) return;
+        if (depotPos == null) {
+            ArsTechnica.LOGGER.warn("tickDepotProcessing: depotPos is null!");
+            return;
+        }
 
         BlockEntity be = world.getBlockEntity(depotPos);
-        if (be == null) return;
+        if (be == null) {
+            if (tickCount % 20 == 0) {
+                ArsTechnica.LOGGER.warn("tickDepotProcessing: No block entity at {}", depotPos);
+            }
+            return;
+        }
         BlockState bs = be.getBlockState();
+        if (tickCount % 20 == 0) {
+            ArsTechnica.LOGGER.info("tickDepotProcessing: Found block entity {} at {}", be, depotPos);
+        }
 
         IItemHandler itemHandler = Capabilities.ItemHandler.BLOCK.getCapability(world, depotPos, bs, be, null);
-        if (itemHandler == null) return;
+        if (itemHandler == null) {
+            if (tickCount % 20 == 0) {
+                ArsTechnica.LOGGER.warn("tickDepotProcessing: No item handler capability for {}", be);
+            }
+            return;
+        }
+        if (tickCount % 20 == 0) {
+            ArsTechnica.LOGGER.info("tickDepotProcessing: Got item handler with {} slots", itemHandler.getSlots());
+        }
 
         for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
             ItemStack stack = itemHandler.getStackInSlot(slot);
+            if (tickCount % 20 == 0) {
+                ArsTechnica.LOGGER.info("tickDepotProcessing: Slot {}: {}", slot, stack);
+            }
             if (stack.isEmpty()) continue;
 
             int extractAmount = Math.min(stack.getCount(), 1);
             ItemStack extracted = itemHandler.extractItem(slot, extractAmount, true);
+            ArsTechnica.LOGGER.info("tickDepotProcessing: Simulated extraction from slot {}: {}", slot, extracted);
             if (extracted.isEmpty()) continue;
 
             FanProcessingType processingType = source.getProcessor();
+            ArsTechnica.LOGGER.info("tickDepotProcessing: ProcessingType={}", processingType);
             if (processingType == null) {
+                ArsTechnica.LOGGER.warn("tickDepotProcessing: No processing type, stopping");
                 return;
             }
 
             ItemEntity temp = new ItemEntity(world, source.getX(), source.getY(), source.getZ(), extracted.copy());
+            temp.setDeltaMovement(Vec3.ZERO);
             CompoundTag saved = depotSlotProcessing.get(slot);
             if (saved != null) {
                 temp.getPersistentData().put("CreateData", saved.copy());
+                CompoundTag processingTag = saved.getCompound("Processing");
+                int timeLeft = processingTag.getInt("Time");
+                ArsTechnica.LOGGER.info("tickDepotProcessing: Restored processing data for slot {}, timeLeft={}", slot, timeLeft);
+            } else {
+                ArsTechnica.LOGGER.info("tickDepotProcessing: No saved processing data for slot {}, will initialize", slot);
             }
             boolean processed = WhirlProcessing.applyProcessing(temp, processingType, world, whirlOwner);
+            CompoundTag afterProcessing = temp.getPersistentData().getCompound("CreateData").getCompound("Processing");
+            int timeAfter = afterProcessing.getInt("Time");
+            ArsTechnica.LOGGER.info("tickDepotProcessing: Processing result for slot {}: processed={}, timeAfter={}", slot, processed, timeAfter);
 
             if (processed) {
+                ArsTechnica.LOGGER.info("tickDepotProcessing: Item finished processing! Extracting from depot");
                 itemHandler.extractItem(slot, extractAmount, false);
-                ItemStack remaining = temp.getItem();
-                if (!remaining.isEmpty() && !ItemStack.isSameItemSameComponents(remaining, extracted)) {
-                    ItemStack leftover = remaining.copy();
-                    leftover = tryInsertIntoHandler(itemHandler, leftover);
-                    if (!leftover.isEmpty()) {
-                        world.addFreshEntity(new ItemEntity(world, source.getX(), source.getY(), source.getZ(), leftover));
-                    }
+                
+                Vec3 itemPosition = new Vec3(source.getX(), source.getY(), source.getZ());
+                sendProcessingFinishedSound(itemPosition, processingType);
+                
+                ItemStack primaryResult = temp.getItem();
+                if (!primaryResult.isEmpty()) {
+                    ArsTechnica.LOGGER.info("tickDepotProcessing: Spawning primary result: {}", primaryResult);
+                    ItemEntity resultEntity = new ItemEntity(world, source.getX(), source.getY(), source.getZ(), primaryResult);
+                    resultEntity.setDeltaMovement(Vec3.ZERO);
+                    resultEntity.setPickUpDelay(10);
+                    world.addFreshEntity(resultEntity);
                 }
+                
                 depotSlotProcessing.remove(slot);
             } else {
+                if (tickCount % 8 == 0) {
+                    Vec3 itemPosition = new Vec3(source.getX(), source.getY(), source.getZ());
+                    sendProcessingSound(itemPosition, processingType);
+                    sendProcessingParticles(world, temp, processingType);
+                }
+                sendProcessingParticles(world, temp, processingType);
+                
                 CompoundTag updated = temp.getPersistentData().getCompound("CreateData");
                 depotSlotProcessing.put(slot, updated.copy());
+                ArsTechnica.LOGGER.info("tickDepotProcessing: Item still processing, saved state for slot {}", slot);
             }
             break;
         }
     }
 
-    private ItemStack tryInsertIntoHandler(IItemHandler handler, ItemStack stack) {
-        ItemStack toInsert = stack;
-        for (int i = 0; i < handler.getSlots() && !toInsert.isEmpty(); i++) {
-            toInsert = handler.insertItem(i, toInsert, false);
-        }
-        return toInsert;
-    }
 
     private void moveItem(Entity entity) {
         Vec3 direction = source.position().subtract(entity.position()).normalize();

--- a/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlProcessing.java
+++ b/src/main/java/com/zeroregard/ars_technica/kinetics/WhirlProcessing.java
@@ -43,6 +43,14 @@ public class WhirlProcessing extends FanProcessing {
         return true;
     }
 
+    public static boolean canProcess(ItemEntity entity, FanProcessingType type) {
+        if (type == null || entity == null || entity.getItem().isEmpty()) {
+            return false;
+        }
+        List<ItemStack> result = type.process(entity.getItem(), entity.level());
+        return result != null && !result.isEmpty();
+    }
+
     private static List<ItemStack> applyCustomProcessing(List<ItemStack> stacks, ItemEntity entity, FanProcessingType type, Level world, SpellResolver whirlOwner) {
         if (SpellResolverHelpers.shouldDoubleOutputs(whirlOwner)) {
             @SuppressWarnings({"rawtypes"})


### PR DESCRIPTION
Add specific handling for Whirl when cast on Create's Depot block to extract and process its items.

This change allows Whirl to interact directly with block inventories like the Depot, establishing a pattern for future block-specific interactions with other glyphs and arcane entities.

---
<a href="https://cursor.com/background-agent?bcId=bc-6004949e-e077-4727-92e1-f4fafec4f824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6004949e-e077-4727-92e1-f4fafec4f824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

