### PR TITLE
Show polish glyph in JEI recipe

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/recipe/SandpaperPolishJeiExtension.java
+++ b/src/main/java/com/zeroregard/ars_technica/recipe/SandpaperPolishJeiExtension.java
@@ -1,0 +1,54 @@
+package com.zeroregard.ars_technica.recipe;
+
+import com.simibubi.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
+import com.zeroregard.ars_technica.ArsTechnica;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JeiPlugin
+public class SandpaperPolishJeiExtension implements IModPlugin {
+
+    public static final mezz.jei.api.recipe.RecipeType<SandPaperPolishingRecipe> SANDPAPER_POLISHING_TYPE = 
+        mezz.jei.api.recipe.RecipeType.create("create", "sandpaper_polishing", SandPaperPolishingRecipe.class);
+
+    @Override
+    public @NotNull ResourceLocation getPluginUid() {
+        return ResourceLocation.fromNamespaceAndPath(ArsTechnica.MODID, "sandpaper_polish_extension");
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        registration.addRecipeCategories(new SandpaperPolishRecipeCategory(registration.getJeiHelpers().getGuiHelper()));
+    }
+
+    @Override
+    public void registerRecipes(@NotNull IRecipeRegistration registration) {
+        assert Minecraft.getInstance().level != null;
+        RecipeManager manager = Minecraft.getInstance().level.getRecipeManager();
+        List<SandPaperPolishingRecipe> polishingRecipes = new ArrayList<>();
+        for (RecipeHolder<?> recipeHolder : manager.getRecipes()) {
+            if (recipeHolder.value() instanceof SandPaperPolishingRecipe recipe) {
+                polishingRecipes.add(recipe);
+            }
+        }
+        registration.addRecipes(SANDPAPER_POLISHING_TYPE, polishingRecipes);
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        // Register catalysts for sandpaper polishing
+        registration.addRecipeCatalyst(new ItemStack(com.simibubi.create.AllItems.SAND_PAPER.get()), SANDPAPER_POLISHING_TYPE);
+    }
+}

--- a/src/main/java/com/zeroregard/ars_technica/recipe/SandpaperPolishRecipeCategory.java
+++ b/src/main/java/com/zeroregard/ars_technica/recipe/SandpaperPolishRecipeCategory.java
@@ -1,0 +1,82 @@
+package com.zeroregard.ars_technica.recipe;
+
+import com.simibubi.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+public class SandpaperPolishRecipeCategory implements IRecipeCategory<SandPaperPolishingRecipe> {
+
+    private final IDrawable background;
+    private final IDrawable icon;
+    private final IGuiHelper guiHelper;
+
+    public SandpaperPolishRecipeCategory(IGuiHelper guiHelper) {
+        this.guiHelper = guiHelper;
+        this.background = guiHelper.createBlankDrawable(120, 60);
+        this.icon = guiHelper.createDrawableItemStack(new net.minecraft.world.item.ItemStack(com.simibubi.create.AllItems.SAND_PAPER.get()));
+    }
+
+    @Override
+    public @NotNull RecipeType<SandPaperPolishingRecipe> getRecipeType() {
+        return SandpaperPolishJeiExtension.SANDPAPER_POLISHING_TYPE;
+    }
+
+    @Override
+    public @NotNull Component getTitle() {
+        return Component.translatable("create.recipe.sandpaper_polishing");
+    }
+
+    @Override
+    public @NotNull IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public @NotNull IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, SandPaperPolishingRecipe recipe, IFocusGroup focuses) {
+        // Add input slot
+        builder.addSlot(RecipeIngredientRole.INPUT, 20, 20)
+                .addIngredients(recipe.getIngredients().get(0));
+        
+        // Add output slot
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 80, 20)
+                .addItemStack(recipe.getResultItem(Minecraft.getInstance().level.registryAccess()));
+    }
+
+    @Override
+    public void draw(SandPaperPolishingRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        // Draw the Polish glyph icon in the bottom left corner
+        Minecraft minecraft = Minecraft.getInstance();
+        
+        // Position the icon in the bottom left corner of the recipe display
+        int iconX = 5; // Left margin
+        int iconY = 5; // Top margin (will be adjusted to bottom)
+        
+        // Get the recipe display height to position at bottom
+        int recipeHeight = 60; // Height of recipe display
+        iconY = recipeHeight - 20; // Position near bottom
+        
+        // Draw the glyph icon
+        ResourceLocation polishGlyphTexture = ResourceLocation.fromNamespaceAndPath("ars_technica", "textures/item/glyph_polish.png");
+        guiGraphics.blit(polishGlyphTexture, iconX, iconY, 0, 0, 16, 16, 16, 16);
+        
+        // Draw a small tooltip text
+        Component tooltip = Component.translatable("ars_technica.jei.polish_glyph_tooltip");
+        guiGraphics.drawString(minecraft.font, tooltip, iconX + 18, iconY + 4, 0xFFFFFF, false);
+    }
+}

--- a/src/main/resources/assets/ars_technica/lang/en_us.json
+++ b/src/main/resources/assets/ars_technica/lang/en_us.json
@@ -121,5 +121,6 @@
 	"entity.ars_technica.arcane_whirl_entity": "Arcane Whirl",
 	"entity.ars_technica.item_projectile_entity": "Item Bubble",
 
-	"item.ars_technica.blank_disc": "Blank Disc"
+	"item.ars_technica.blank_disc": "Blank Disc",
+	"ars_technica.jei.polish_glyph_tooltip": "Polish Glyph Available"
 }


### PR DESCRIPTION
Display Polish glyph icon in Sandpaper Polishing JEI recipes to enhance player discoverability.

---
<a href="https://cursor.com/background-agent?bcId=bc-49ad1a43-93e6-4776-a230-2052fecd41b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49ad1a43-93e6-4776-a230-2052fecd41b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

