### PR TITLE
Add fuse recipe filtering and exclusive recipe type

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/Config.java
+++ b/src/main/java/com/zeroregard/ars_technica/Config.java
@@ -14,6 +14,7 @@ public class Config {
         public static ModConfigSpec.BooleanValue FLUID_CAN_BE_PLACED;
         public static ModConfigSpec.BooleanValue FLUID_SOURCES_CAN_BE_PLACED;
         public static ModConfigSpec.IntValue FLUID_MAX_PLACEMENTS_PER_FUSE;
+        public static ModConfigSpec.ConfigValue<java.util.List<? extends String>> FUSE_RECIPE_FILTER;
 
         public static ModConfigSpec.ConfigValue<Double> SOURCE_MOTOR_SPEED_TO_SOURCE_MULTIPLIER;
 
@@ -55,6 +56,8 @@ public class Config {
             FLUID_CAN_BE_PLACED = builder.define("fluidCanBePlaced", true);
             FLUID_SOURCES_CAN_BE_PLACED = builder.define("fluidSourcesCanBePlaced", true);
             FLUID_MAX_PLACEMENTS_PER_FUSE = builder.defineInRange("fluidMaxPlacementsPerFuse", 16, 1, 256);
+            FUSE_RECIPE_FILTER = builder.comment("List of recipe IDs (namespace:path) that Fuse should ignore when scanning for recipes")
+                    .defineList("recipeFilter", java.util.List.of(), entry -> entry instanceof String string && net.minecraft.resources.ResourceLocation.tryParse(string) != null);
 
             builder.pop();
 

--- a/src/main/java/com/zeroregard/ars_technica/entity/fusion/ArcaneFusionEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/fusion/ArcaneFusionEntity.java
@@ -2,11 +2,11 @@ package com.zeroregard.ars_technica.entity.fusion;
 
 import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
-import com.simibubi.create.content.kinetics.mixer.MixingRecipe;
 import com.zeroregard.ars_technica.entity.Colorable;
 import com.zeroregard.ars_technica.entity.fusion.fluids.ArcaneFusionFluids;
 import com.zeroregard.ars_technica.entity.fusion.fluids.FluidSourceProvider;
 import com.zeroregard.ars_technica.helpers.FluidHelper;
+import com.zeroregard.ars_technica.helpers.FuseRecipeLike;
 import com.zeroregard.ars_technica.helpers.MixingRecipeHelpers;
 import com.zeroregard.ars_technica.registry.EntityRegistry;
 import com.zeroregard.ars_technica.registry.SoundRegistry;
@@ -246,7 +246,6 @@ public class ArcaneFusionEntity extends Entity implements GeoEntity, Colorable {
                 particleHandler.setIngredientsForParticles(ingredients);
             }
 
-            // Remove the used items based on count
             ingredients.forEach(itemEntity -> {
                 var item = itemEntity.getItem();
                 item.setCount(item.getCount() - clampedRecipeIterations);
@@ -255,9 +254,7 @@ public class ArcaneFusionEntity extends Entity implements GeoEntity, Colorable {
                 }
             });
 
-            // Remove the used fluids
             fluidIngredients.forEach(fluidSource -> {
-                // Find the matching fluid ingredient for this fluid source
                 var requiredFluidIngredient = recipe.getFluidIngredients().stream()
                         .filter(ingredient -> ingredient.ingredient().test(fluidSource.getFluidStack()))
                         .findFirst()
@@ -284,7 +281,7 @@ public class ArcaneFusionEntity extends Entity implements GeoEntity, Colorable {
         playWorldSound(SoundRegistry.FUSE_FAILED.get(), 0.75f, 1.0f);
     }
 
-    private void setItemResult(MixingRecipe recipe, int recipeIterations) {
+    private void setItemResult(FuseRecipeLike recipe, int recipeIterations) {
         RegistryAccess registryAccess = world.registryAccess();
         ItemStack recipeItemResult = recipe.getResultItem(registryAccess);
         var itemOutput = recipeItemResult.copy();
@@ -292,7 +289,7 @@ public class ArcaneFusionEntity extends Entity implements GeoEntity, Colorable {
         resultEntity = new ItemEntity(world, getX(), getY(), getZ(), itemOutput);
     }
 
-    private void setFluidResult(MixingRecipe recipe, int recipeIterations) {
+    private void setFluidResult(FuseRecipeLike recipe, int recipeIterations) {
         List<FluidStack> fluidResults = recipe.getFluidResults();
         resultLiquids = fluidResults.stream()
                 .map(fluidStack -> {

--- a/src/main/java/com/zeroregard/ars_technica/helpers/FuseRecipeFilter.java
+++ b/src/main/java/com/zeroregard/ars_technica/helpers/FuseRecipeFilter.java
@@ -1,0 +1,22 @@
+package com.zeroregard.ars_technica.helpers;
+
+import com.zeroregard.ars_technica.Config;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Objects;
+
+public final class FuseRecipeFilter {
+    private FuseRecipeFilter() {
+    }
+
+    public static boolean isFiltered(ResourceLocation id) {
+        if (id == null) {
+            return false;
+        }
+        return Config.Common.FUSE_RECIPE_FILTER.get().stream()
+                .map(Object::toString)
+                .map(ResourceLocation::tryParse)
+                .filter(Objects::nonNull)
+                .anyMatch(id::equals);
+    }
+}

--- a/src/main/java/com/zeroregard/ars_technica/helpers/FuseRecipeLike.java
+++ b/src/main/java/com/zeroregard/ars_technica/helpers/FuseRecipeLike.java
@@ -1,0 +1,17 @@
+package com.zeroregard.ars_technica.helpers;
+
+import com.simibubi.create.content.processing.recipe.HeatCondition;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
+
+public interface FuseRecipeLike {
+    HeatCondition getRequiredHeat();
+    NonNullList<Ingredient> getIngredients();
+    NonNullList<SizedFluidIngredient> getFluidIngredients();
+    NonNullList<FluidStack> getFluidResults();
+    ItemStack getResultItem(HolderLookup.Provider access);
+}

--- a/src/main/java/com/zeroregard/ars_technica/helpers/MixingRecipeHelpers.java
+++ b/src/main/java/com/zeroregard/ars_technica/helpers/MixingRecipeHelpers.java
@@ -4,6 +4,8 @@ import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.kinetics.mixer.MixingRecipe;
 import com.zeroregard.ars_technica.entity.fusion.ArcaneFusionType;
 import com.zeroregard.ars_technica.entity.fusion.fluids.FluidSourceProvider;
+import com.zeroregard.ars_technica.recipe.FuseMixingRecipe;
+import com.zeroregard.ars_technica.registry.RecipeRegistry;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -11,6 +13,7 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.*;
 
@@ -18,23 +21,16 @@ public class MixingRecipeHelpers {
 
     public static Optional<MixingRecipeResult> getMixingRecipe(List<ItemEntity> items, List<FluidSourceProvider> fluids, Level world, ArcaneFusionType fusionType) {
         RecipeManager recipeManager = world.getRecipeManager();
-        var mixingRecipes = recipeManager.getAllRecipesFor(AllRecipeTypes.MIXING.getType())
-                .stream()
-                .map(RecipeHolder::value)
-                .filter(recipe -> recipe instanceof MixingRecipe)
-                .map(MixingRecipe.class::cast)
-                .filter(x -> x.getRequiredHeat() == fusionType.getSuppliedHeat())
-                .toList();
+        var fuseRecipes = gatherEligibleRecipes(recipeManager, fusionType);
 
-        for (MixingRecipe mixingRecipe : mixingRecipes) {
+        for (FuseRecipeLike fuseRecipe : fuseRecipes) {
             ArrayList<ItemEntity> usedEntities = new ArrayList<>();
             ArrayList<FluidSourceProvider> usedFluids = new ArrayList<>();
 
-
-            boolean matches = mixingRecipeIngredientsMatch(mixingRecipe, items, fluids, usedEntities, usedFluids);
+            boolean matches = mixingRecipeIngredientsMatch(fuseRecipe, items, fluids, usedEntities, usedFluids);
 
             if (matches) {
-                MixingRecipeResult result = new MixingRecipeResult(mixingRecipe, usedEntities, usedFluids);
+                MixingRecipeResult result = new MixingRecipeResult(fuseRecipe, usedEntities, usedFluids);
                 return Optional.of(result);
             }
         }
@@ -42,12 +38,36 @@ public class MixingRecipeHelpers {
         return Optional.empty();
     }
 
+    private static List<FuseRecipeLike> gatherEligibleRecipes(RecipeManager recipeManager, ArcaneFusionType fusionType) {
+        ArrayList<FuseRecipeLike> fuseRecipes = new ArrayList<>();
+        for (RecipeHolder<?> holder : recipeManager.getAllRecipesFor(AllRecipeTypes.MIXING.getType())) {
+            if (FuseRecipeFilter.isFiltered(holder.id())) {
+                continue;
+            }
+            var value = holder.value();
+            if (value instanceof MixingRecipe recipe && recipe.getRequiredHeat() == fusionType.getSuppliedHeat()) {
+                fuseRecipes.add(new CreateMixingRecipeAdapter(recipe));
+            }
+        }
+
+        for (RecipeHolder<?> holder : recipeManager.getAllRecipesFor(RecipeRegistry.FUSE_MIXING_TYPE.get())) {
+            if (FuseRecipeFilter.isFiltered(holder.id())) {
+                continue;
+            }
+            var value = holder.value();
+            if (value instanceof FuseMixingRecipe recipe && recipe.getRequiredHeat() == fusionType.getSuppliedHeat()) {
+                fuseRecipes.add(recipe);
+            }
+        }
+        return fuseRecipes;
+    }
+
     public static class MixingRecipeResult {
-        public MixingRecipe recipe;
+        public FuseRecipeLike recipe;
         public List<ItemEntity> usedEntities;
         public List<FluidSourceProvider> usedFluids;
 
-        public MixingRecipeResult(MixingRecipe recipe, List<ItemEntity> usedEntities, List<FluidSourceProvider> usedFluids) {
+        public MixingRecipeResult(FuseRecipeLike recipe, List<ItemEntity> usedEntities, List<FluidSourceProvider> usedFluids) {
             this.recipe = recipe;
             this.usedEntities = usedEntities;
             this.usedFluids = usedFluids;
@@ -55,17 +75,15 @@ public class MixingRecipeHelpers {
     }
 
     private static boolean mixingRecipeIngredientsMatch(
-            MixingRecipe recipe,
+            FuseRecipeLike recipe,
             List<ItemEntity> availableItems,
             List<FluidSourceProvider> availableFluids,
             List<ItemEntity> usedEntities,
             List<FluidSourceProvider> usedFluids
     ) {
 
-        // Dictionary to track how many times each item entity has been used, because some recipes call for the same or similar ingredient many times
         Map<ItemEntity, Integer> usageMap = new HashMap<>();
 
-        // Match item requirements
         for (Ingredient itemIngredient : recipe.getIngredients()) {
             for(ItemStack ingredientVariant : itemIngredient.getItems()) {
                 var itemCandidate = availableItems.stream().filter(item -> item.getItem().getItem() == ingredientVariant.getItem()).findFirst();
@@ -86,11 +104,10 @@ public class MixingRecipeHelpers {
             return false;
         }
 
-        // Match fluid requirements
-        for (var fluidIngredient : recipe.getFluidIngredients()) {
+        for (SizedFluidIngredient fluidIngredient : recipe.getFluidIngredients()) {
             var fluidCandidate = availableFluids.stream()
-                .filter(fluid -> fluidIngredient.ingredient().test(fluid.getFluidStack()))
-                .findFirst();
+                    .filter(fluid -> fluidIngredient.ingredient().test(fluid.getFluidStack()))
+                    .findFirst();
             if(fluidCandidate.isPresent()) {
                 var candidateUnwrapped = fluidCandidate.get();
                 if(candidateUnwrapped.getMbAmount() >= fluidIngredient.amount()) {
@@ -100,5 +117,32 @@ public class MixingRecipeHelpers {
         }
 
         return usedEntities.size() == recipe.getIngredients().size() && usedFluids.size() == recipe.getFluidIngredients().size();
+    }
+
+    private record CreateMixingRecipeAdapter(MixingRecipe delegate) implements FuseRecipeLike {
+        @Override
+        public com.simibubi.create.content.processing.recipe.HeatCondition getRequiredHeat() {
+            return delegate.getRequiredHeat();
+        }
+
+        @Override
+        public net.minecraft.core.NonNullList<Ingredient> getIngredients() {
+            return delegate.getIngredients();
+        }
+
+        @Override
+        public net.minecraft.core.NonNullList<SizedFluidIngredient> getFluidIngredients() {
+            return delegate.getFluidIngredients();
+        }
+
+        @Override
+        public net.minecraft.core.NonNullList<FluidStack> getFluidResults() {
+            return delegate.getFluidResults();
+        }
+
+        @Override
+        public net.minecraft.world.item.ItemStack getResultItem(net.minecraft.core.HolderLookup.Provider access) {
+            return delegate.getResultItem(access);
+        }
     }
 }

--- a/src/main/java/com/zeroregard/ars_technica/recipe/FuseMixingRecipe.java
+++ b/src/main/java/com/zeroregard/ars_technica/recipe/FuseMixingRecipe.java
@@ -1,0 +1,169 @@
+package com.zeroregard.ars_technica.recipe;
+
+import com.simibubi.create.content.processing.recipe.HeatCondition;
+import com.zeroregard.ars_technica.helpers.FuseRecipeLike;
+import com.zeroregard.ars_technica.registry.RecipeRegistry;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeInput;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class FuseMixingRecipe implements Recipe<RecipeInput>, FuseRecipeLike {
+    private final NonNullList<Ingredient> ingredients;
+    private final NonNullList<SizedFluidIngredient> fluidIngredients;
+    private final NonNullList<FluidStack> fluidResults;
+    private final ItemStack result;
+    private final HeatCondition requiredHeat;
+
+    public FuseMixingRecipe(NonNullList<Ingredient> ingredients,
+                            NonNullList<SizedFluidIngredient> fluidIngredients,
+                            NonNullList<FluidStack> fluidResults,
+                            ItemStack result,
+                            HeatCondition requiredHeat) {
+        this.ingredients = ingredients;
+        this.fluidIngredients = fluidIngredients;
+        this.fluidResults = fluidResults;
+        this.result = result;
+        this.requiredHeat = requiredHeat;
+    }
+
+    @Override
+    public boolean matches(@NotNull RecipeInput recipeInput, @NotNull Level level) {
+        return false;
+    }
+
+    @Override
+    public @NotNull ItemStack assemble(@NotNull RecipeInput recipeInput, @NotNull HolderLookup.Provider access) {
+        return result.copy();
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height) {
+        return false;
+    }
+
+    @Override
+    public @NotNull ItemStack getResultItem(@NotNull HolderLookup.Provider access) {
+        return result.copy();
+    }
+
+    @Override
+    public @NotNull NonNullList<Ingredient> getIngredients() {
+        return ingredients;
+    }
+
+    @Override
+    public boolean isSpecial() {
+        return true;
+    }
+
+    @Override
+    public @NotNull RecipeSerializer<?> getSerializer() {
+        return RecipeRegistry.FUSE_MIXING_SERIALIZER.get();
+    }
+
+    @Override
+    public @NotNull RecipeType<?> getType() {
+        return RecipeRegistry.FUSE_MIXING_TYPE.get();
+    }
+
+    @Override
+    public HeatCondition getRequiredHeat() {
+        return requiredHeat;
+    }
+
+    @Override
+    public NonNullList<SizedFluidIngredient> getFluidIngredients() {
+        return fluidIngredients;
+    }
+
+    @Override
+    public NonNullList<FluidStack> getFluidResults() {
+        return fluidResults;
+    }
+
+    public static class Serializer implements RecipeSerializer<FuseMixingRecipe> {
+        @Override
+        public com.mojang.serialization.MapCodec<FuseMixingRecipe> codec() {
+            return com.mojang.serialization.codecs.RecordCodecBuilder.mapCodec(instance -> instance.group(
+                    Ingredient.CODEC.listOf().fieldOf("ingredients").forGetter(recipe -> recipe.ingredients),
+                    SizedFluidIngredient.NESTED_CODEC.listOf().optionalFieldOf("fluid_ingredients", List.of()).forGetter(recipe -> recipe.fluidIngredients),
+                    FluidStack.CODEC.listOf().optionalFieldOf("fluid_results", List.of()).forGetter(recipe -> recipe.fluidResults),
+                    ItemStack.CODEC.fieldOf("result").forGetter(recipe -> recipe.result),
+                    HeatCondition.CODEC.optionalFieldOf("heat", HeatCondition.NONE).forGetter(recipe -> recipe.requiredHeat)
+            ).apply(instance, (ingredients, fluidIngredients, fluidResults, result, heat) ->
+                    fromCodecValues(ingredients, fluidIngredients, fluidResults, result, heat)));
+        }
+
+        @Override
+        public StreamCodec<RegistryFriendlyByteBuf, FuseMixingRecipe> streamCodec() {
+            return STREAM_CODEC;
+        }
+
+        private static final StreamCodec<RegistryFriendlyByteBuf, FuseMixingRecipe> STREAM_CODEC = new StreamCodec<>() {
+            @Override
+            public FuseMixingRecipe decode(RegistryFriendlyByteBuf buffer) {
+                var ingredients = readList(buffer, Ingredient.CONTENTS_STREAM_CODEC);
+                var fluidIngredients = readList(buffer, SizedFluidIngredient.STREAM_CODEC);
+                var fluidResults = readList(buffer, FluidStack.STREAM_CODEC);
+                ItemStack result = ItemStack.STREAM_CODEC.decode(buffer);
+                HeatCondition heat = HeatCondition.values()[buffer.readVarInt()];
+                return new FuseMixingRecipe(ingredients, fluidIngredients, fluidResults, result, heat);
+            }
+
+            @Override
+            public void encode(RegistryFriendlyByteBuf buffer, FuseMixingRecipe recipe) {
+                writeList(buffer, recipe.ingredients, Ingredient.CONTENTS_STREAM_CODEC);
+                writeList(buffer, recipe.fluidIngredients, SizedFluidIngredient.STREAM_CODEC);
+                writeList(buffer, recipe.fluidResults, FluidStack.STREAM_CODEC);
+                ItemStack.STREAM_CODEC.encode(buffer, recipe.result.copy());
+                buffer.writeVarInt(recipe.requiredHeat.ordinal());
+            }
+
+            private <T> void writeList(RegistryFriendlyByteBuf buffer, List<T> values, StreamCodec<RegistryFriendlyByteBuf, T> codec) {
+                buffer.writeVarInt(values.size());
+                for (T value : values) {
+                    codec.encode(buffer, value);
+                }
+            }
+
+            private <T> NonNullList<T> readList(RegistryFriendlyByteBuf buffer, StreamCodec<RegistryFriendlyByteBuf, T> codec) {
+                int size = buffer.readVarInt();
+                NonNullList<T> list = NonNullList.create();
+                for (int i = 0; i < size; i++) {
+                    list.add(codec.decode(buffer));
+                }
+                return list;
+            }
+        };
+
+        private static FuseMixingRecipe fromCodecValues(List<Ingredient> ingredients,
+                                                        List<SizedFluidIngredient> fluidIngredients,
+                                                        List<FluidStack> fluidResults,
+                                                        ItemStack result,
+                                                        HeatCondition heat) {
+            return new FuseMixingRecipe(copyIntoNonNullList(ingredients),
+                    copyIntoNonNullList(fluidIngredients),
+                    copyIntoNonNullList(fluidResults),
+                    result, heat);
+        }
+    }
+
+    private static <T> NonNullList<T> copyIntoNonNullList(List<T> source) {
+        NonNullList<T> list = NonNullList.create();
+        list.addAll(source);
+        return list;
+    }
+}

--- a/src/main/java/com/zeroregard/ars_technica/recipe/FuseMixingRecipeCategory.java
+++ b/src/main/java/com/zeroregard/ars_technica/recipe/FuseMixingRecipeCategory.java
@@ -1,0 +1,78 @@
+package com.zeroregard.ars_technica.recipe;
+
+import com.simibubi.create.content.processing.recipe.HeatCondition;
+import com.zeroregard.ars_technica.registry.ItemRegistry;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.constants.VanillaTypes;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class FuseMixingRecipeCategory implements IRecipeCategory<FuseMixingRecipe> {
+    private final IDrawable background;
+    private final IDrawable icon;
+
+    public FuseMixingRecipeCategory(IGuiHelper helper) {
+        this.background = helper.createBlankDrawable(150, 70);
+        ItemStack iconStack = new ItemStack(ItemRegistry.CALIBRATED_PRECISION_MECHANISM.get());
+        this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, iconStack);
+    }
+
+    @Override
+    public @NotNull RecipeType<FuseMixingRecipe> getRecipeType() {
+        return JeiFusePlugin.FUSE_MIXING_TYPE;
+    }
+
+    @Override
+    public @NotNull Component getTitle() {
+        return Component.translatable("jei.ars_technica.category.fuse_mixing");
+    }
+
+    @Override
+    public @NotNull IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public @NotNull IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void setRecipe(@NotNull IRecipeLayoutBuilder builder, FuseMixingRecipe recipe, @NotNull IFocusGroup focuses) {
+        int column = 0;
+        int row = 0;
+        for (var ingredient : recipe.getIngredients()) {
+            builder.addSlot(RecipeIngredientRole.INPUT, 5 + column * 18, 5 + row * 18)
+                    .addIngredients(ingredient);
+            column++;
+            if (column >= 4) {
+                column = 0;
+                row++;
+            }
+        }
+
+        RegistryAccess access = Minecraft.getInstance().level != null ? Minecraft.getInstance().level.registryAccess() : RegistryAccess.EMPTY;
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 120, 10)
+                .addItemStack(recipe.getResultItem(access));
+    }
+
+    @Override
+    public void draw(FuseMixingRecipe recipe, @NotNull IRecipeSlotsView slotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        HeatCondition heat = recipe.getRequiredHeat();
+        Component heatText = Component.translatable("jei.ars_technica.category.fuse_mixing.heat", Component.translatable(heat.getTranslationKey()));
+        Font font = Minecraft.getInstance().font;
+        guiGraphics.drawString(font, heatText, 5, 58, 0x3A3A3A, false);
+    }
+}

--- a/src/main/java/com/zeroregard/ars_technica/recipe/JeiFusePlugin.java
+++ b/src/main/java/com/zeroregard/ars_technica/recipe/JeiFusePlugin.java
@@ -1,0 +1,57 @@
+package com.zeroregard.ars_technica.recipe;
+
+import com.zeroregard.ars_technica.ArsTechnica;
+import com.zeroregard.ars_technica.helpers.FuseRecipeFilter;
+import com.zeroregard.ars_technica.registry.ItemRegistry;
+import com.zeroregard.ars_technica.registry.RecipeRegistry;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@JeiPlugin
+public class JeiFusePlugin implements IModPlugin {
+    public static final RecipeType<FuseMixingRecipe> FUSE_MIXING_TYPE = RecipeType.create(ArsTechnica.MODID, "fuse_mixing", FuseMixingRecipe.class);
+
+    @Override
+    public @NotNull ResourceLocation getPluginUid() {
+        return ArsTechnica.prefix("fuse_only");
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registry) {
+        registry.addRecipeCategories(new FuseMixingRecipeCategory(registry.getJeiHelpers().getGuiHelper()));
+    }
+
+    @Override
+    public void registerRecipes(@NotNull IRecipeRegistration registry) {
+        assert Minecraft.getInstance().level != null;
+        var manager = Minecraft.getInstance().level.getRecipeManager();
+        List<FuseMixingRecipe> recipes = manager.getAllRecipesFor(RecipeRegistry.FUSE_MIXING_TYPE.get()).stream()
+                .filter(holder -> !FuseRecipeFilter.isFiltered(holder.id()))
+                .map(RecipeHolder::value)
+                .toList();
+        registry.addRecipes(FUSE_MIXING_TYPE, recipes);
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registry) {
+        registry.addRecipeCatalyst(getFuseGlyphStack(), FUSE_MIXING_TYPE);
+    }
+
+    private ItemStack getFuseGlyphStack() {
+        return BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse("ars_nouveau:glyph_fuse"))
+                .map(ItemStack::new)
+                .orElseGet(() -> new ItemStack(ItemRegistry.CALIBRATED_PRECISION_MECHANISM.get()));
+    }
+}

--- a/src/main/java/com/zeroregard/ars_technica/registry/RecipeRegistry.java
+++ b/src/main/java/com/zeroregard/ars_technica/registry/RecipeRegistry.java
@@ -1,6 +1,7 @@
 package com.zeroregard.ars_technica.registry;
 
 import com.zeroregard.ars_technica.ArsTechnica;
+import com.zeroregard.ars_technica.recipe.FuseMixingRecipe;
 import com.zeroregard.ars_technica.recipe.TechnomancerArmorRecipe;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.crafting.RecipeSerializer;
@@ -23,10 +24,14 @@ public class RecipeRegistry {
 
   public static final DeferredHolder<RecipeType<?>, RecipeType<TechnomancerArmorRecipe>> TECHNOMANCER_ARMOR_UP;
   public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TechnomancerArmorRecipe>> TECHNOMANCER_ARMOR_UP_SERIALIZER;
+  public static final DeferredHolder<RecipeType<?>, RecipeType<FuseMixingRecipe>> FUSE_MIXING_TYPE;
+  public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<FuseMixingRecipe>> FUSE_MIXING_SERIALIZER;
 
   static {
     TECHNOMANCER_ARMOR_UP = RECIPES.register("armor_upgrade", () -> RecipeType.simple(prefix("armor_upgrade")));
     TECHNOMANCER_ARMOR_UP_SERIALIZER = SERIALIZERS.register("armor_upgrade", TechnomancerArmorRecipe.Serializer::new);
+    FUSE_MIXING_TYPE = RECIPES.register("fuse_mixing", () -> RecipeType.simple(prefix("fuse_mixing")));
+    FUSE_MIXING_SERIALIZER = SERIALIZERS.register("fuse_mixing", FuseMixingRecipe.Serializer::new);
   }
 
 }

--- a/src/main/resources/assets/ars_technica/lang/en_us.json
+++ b/src/main/resources/assets/ars_technica/lang/en_us.json
@@ -125,5 +125,7 @@
 	"entity.ars_technica.arcane_whirl_entity": "Arcane Whirl",
 	"entity.ars_technica.item_projectile_entity": "Item Bubble",
 
-	"item.ars_technica.blank_disc": "Blank Disc"
+	"item.ars_technica.blank_disc": "Blank Disc",
+	"jei.ars_technica.category.fuse_mixing": "Fuse Mixing",
+	"jei.ars_technica.category.fuse_mixing.heat": "Heat: %s"
 }

--- a/src/main/resources/data/ars_technica/recipes/fuse/calibrated_precision_mechanism.json
+++ b/src/main/resources/data/ars_technica/recipes/fuse/calibrated_precision_mechanism.json
@@ -1,0 +1,12 @@
+{
+  "type": "ars_technica:fuse_mixing",
+  "heat": "superheated",
+  "ingredients": [
+    {
+      "item": "ars_technica:calibrated_precision_mechanism"
+    }
+  ],
+  "result": {
+    "item": "create:precision_mechanism"
+  }
+}


### PR DESCRIPTION
Adds recipe filtering for Fuse and introduces a new `fuse_mixing` recipe type with a dedicated JEI category for Fuse-exclusive mixing recipes.

The new `fuse_mixing` recipe type allows content creators to define recipes specifically for Fuse, preventing conflicts or unintended interactions with Create's existing mixing recipes, while the filtering provides granular control over which recipes Fuse processes.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7079656-3a85-43f6-8841-0d891c36279b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7079656-3a85-43f6-8841-0d891c36279b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

