### PR TITLE
fix: press and polish duplicating items

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
@@ -134,7 +134,10 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
     }
 
     protected void growOutput(ItemEntity input, ItemStack outputStack) {
-        if (currentOutput != null && currentOutput.getItem().getItem() == outputStack.getItem() && currentOutput.getItem().getCount() < currentOutput.getItem().getMaxStackSize()) {
+        if (currentOutput != null && currentOutput.isRemoved()) {
+            currentOutput = null;
+        }
+        if (currentOutput != null && !currentOutput.isRemoved() && currentOutput.getItem().getItem() == outputStack.getItem() && currentOutput.getItem().getCount() < currentOutput.getItem().getMaxStackSize()) {
             ItemStack currentOutputItem = currentOutput.getItem();
             ItemStack newStack = currentOutputItem.copyWithCount(currentOutputItem.getCount() + 1);
             currentOutput.discard();

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
@@ -137,7 +137,7 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
         if (currentOutput != null && currentOutput.isRemoved()) {
             currentOutput = null;
         }
-        if (currentOutput != null && !currentOutput.isRemoved() && currentOutput.getItem().getItem() == outputStack.getItem() && currentOutput.getItem().getCount() < currentOutput.getItem().getMaxStackSize()) {
+        if (currentOutput != null && currentOutput.getItem().getItem() == outputStack.getItem() && currentOutput.getItem().getCount() < currentOutput.getItem().getMaxStackSize()) {
             ItemStack currentOutputItem = currentOutput.getItem();
             ItemStack newStack = currentOutputItem.copyWithCount(currentOutputItem.getCount() + 1);
             currentOutput.discard();
@@ -145,9 +145,6 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
             currentOutput = new ItemEntity(world, input.getX(), input.getY(), input.getZ(), newStack);
             world.addFreshEntity(currentOutput);
         } else {
-            if (currentOutput != null && !currentOutput.isRemoved()) {
-                currentOutput.discard();
-            }
             currentOutput = new ItemEntity(world, input.getX(), input.getY(), input.getZ(), outputStack);
             world.addFreshEntity(currentOutput);
         }

--- a/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
+++ b/src/main/java/com/zeroregard/ars_technica/entity/ArcaneProcessEntity.java
@@ -142,6 +142,9 @@ public abstract class ArcaneProcessEntity extends Entity implements Colorable {
             currentOutput = new ItemEntity(world, input.getX(), input.getY(), input.getZ(), newStack);
             world.addFreshEntity(currentOutput);
         } else {
+            if (currentOutput != null && !currentOutput.isRemoved()) {
+                currentOutput.discard();
+            }
             currentOutput = new ItemEntity(world, input.getX(), input.getY(), input.getZ(), outputStack);
             world.addFreshEntity(currentOutput);
         }


### PR DESCRIPTION
Discard existing output entities before creating new ones to prevent duplicate items from Press and Polish effects.

The `growOutput` method was creating a new output entity without discarding the old one when the existing `currentOutput` couldn't be merged (e.g., different item or max stack size), leading to multiple output entities for a single process.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4e5172a-7a15-4a05-ae01-f75ee99ce8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4e5172a-7a15-4a05-ae01-f75ee99ce8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

