### PR TITLE
Telefeast potion flask compatibility

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectTelefeast.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectTelefeast.java
@@ -1,6 +1,9 @@
 package com.zeroregard.ars_technica.glyphs;
 
 import com.hollingsworth.arsnouveau.api.spell.*;
+import com.hollingsworth.arsnouveau.api.potion.IPotionProvider;
+import com.hollingsworth.arsnouveau.api.registry.PotionProviderRegistry;
+import com.hollingsworth.arsnouveau.common.items.PotionFlask;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
 import com.simibubi.create.AllRecipeTypes;
@@ -91,6 +94,25 @@ public class EffectTelefeast extends AbstractEffect {
             if (!itemStack.isEmpty()) {
                 if(forwardItem && (isFood(itemStack, null) || isDrink(itemStack))) {
                     ItemStack extractedItem = itemHandler.extractItem(i, 1, false);
+                    
+                    if (extractedItem.getItem() instanceof PotionFlask) {
+                        IPotionProvider data = PotionProviderRegistry.from(extractedItem);
+                        if (data != null && data.usesRemaining(extractedItem) > 0) {
+                            ItemStack copyItem = extractedItem.copy();
+                            IPotionProvider copyData = PotionProviderRegistry.from(copyItem);
+                            if (copyData != null) {
+                                copyData.setData(data.getPotionData(extractedItem), 1, data.maxUses(extractedItem), copyItem);
+                                data.consumeUses(extractedItem, 1, null);
+                                itemHandler.insertItem(i, extractedItem, false);
+                                forwardItem(world, copyItem, direction, position.getCenter());
+                                break;
+                            }
+                        } else {
+                            itemHandler.insertItem(i, extractedItem, false);
+                            continue;
+                        }
+                    }
+                    
                     ItemStack emptyContainer = getEmptyContainer(extractedItem, world);
                     if (!emptyContainer.isEmpty()) {
                         itemHandler.insertItem(i, emptyContainer, false);

--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectTelefeast.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectTelefeast.java
@@ -101,7 +101,7 @@ public class EffectTelefeast extends AbstractEffect {
 
                 if(canUse || isDrink(itemStack) || isFood(itemStack, null)) {
                     ItemStack extractedItem = itemHandler.extractItem(i, 1, false);
-                    ItemStack emptyContainer = getEmptyContainer(extractedItem, world);
+                    ItemStack originalItem = extractedItem.copy();
                     boolean consumed = false;
                     
                     if(ConsumptionHelper.tryUseConsumableItem(caster, extractedItem, world, canUse)) {
@@ -111,8 +111,13 @@ public class EffectTelefeast extends AbstractEffect {
                     }
                     
                     if(consumed) {
-                        if (!emptyContainer.isEmpty()) {
-                            itemHandler.insertItem(i, emptyContainer, false);
+                        if (!extractedItem.isEmpty()) {
+                            itemHandler.insertItem(i, extractedItem, false);
+                        } else {
+                            ItemStack emptyContainer = getEmptyContainer(originalItem, world);
+                            if (!emptyContainer.isEmpty()) {
+                                itemHandler.insertItem(i, emptyContainer, false);
+                            }
                         }
                         break;
                     } else {

--- a/src/main/java/com/zeroregard/ars_technica/helpers/ConsumptionHelper.java
+++ b/src/main/java/com/zeroregard/ars_technica/helpers/ConsumptionHelper.java
@@ -1,5 +1,8 @@
 package com.zeroregard.ars_technica.helpers;
 
+import com.hollingsworth.arsnouveau.api.potion.IPotionProvider;
+import com.hollingsworth.arsnouveau.api.registry.PotionProviderRegistry;
+import com.hollingsworth.arsnouveau.common.items.PotionFlask;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -10,6 +13,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.PotionItem;
 import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,6 +21,9 @@ public class ConsumptionHelper {
 
     public static boolean tryUseEdibleItem(LivingEntity consumer, ItemStack itemStack, Level world) {
         if (isDrink((itemStack))) {
+            if (itemStack.getItem() instanceof PotionFlask && !canConsumeArsNouveauPotionFlask(itemStack)) {
+                return false;
+            }
             itemStack.finishUsingItem(world, consumer);
             playSound(SoundEvents.GENERIC_DRINK, world, consumer);
             return true;
@@ -49,6 +56,9 @@ public class ConsumptionHelper {
             try {
                 player.setItemInHand(temporaryHand, itemStack);
                 if (isDrink(itemStack)) {
+                    if (itemStack.getItem() instanceof PotionFlask && !canConsumeArsNouveauPotionFlask(itemStack)) {
+                        return false;
+                    }
                     itemStack.finishUsingItem(world, player);
                     playSound(SoundEvents.GENERIC_DRINK, world, consumer);
                     return true;
@@ -70,5 +80,10 @@ public class ConsumptionHelper {
 
     public static void playSound(SoundEvent event, Level world, LivingEntity consumer) {
         world.playSound(null, consumer.getX(), consumer.getY(), consumer.getZ(), event, SoundSource.NEUTRAL, 1.0F, 1.0F);
+    }
+
+    private static boolean canConsumeArsNouveauPotionFlask(ItemStack stack) {
+        IPotionProvider data = PotionProviderRegistry.from(stack);
+        return data != null && data.getPotionData(stack) != PotionContents.EMPTY && data.usesRemaining(stack) > 0;
     }
 }


### PR DESCRIPTION
Preserve Ars Nouveau Potion Flasks when used with Telefeast, preventing their destruction.

Telefeast's consumption logic was updated to re-insert the original item stack if it's not empty after use (as Potion Flasks do, decrementing charges). A safeguard was also added to ensure Potion Flasks are only consumed if they have remaining uses, aligning with Ars Nouveau's intended item behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e18ef5f-3728-45c2-a610-1edde1a4ef67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e18ef5f-3728-45c2-a610-1edde1a4ef67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

