### PR TITLE
Glyph insert item handlers

### DIFF
--- a/src/main/java/com/zeroregard/ars_technica/glyphs/EffectInsert.java
+++ b/src/main/java/com/zeroregard/ars_technica/glyphs/EffectInsert.java
@@ -6,7 +6,6 @@ import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSplit;
 import com.zeroregard.ars_technica.helpers.StorageHelpers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.Container;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -124,7 +123,7 @@ public class EffectInsert extends AbstractItemResolveEffect {
         BlockPos maxPos = pos.offset(expansion, expansion, expansion);
         for (BlockPos currentPos : BlockPos.betweenClosed(minPos, maxPos)) {
             BlockEntity tileEntity = world.getBlockEntity(currentPos);
-            if (tileEntity instanceof Container) {
+            if (tileEntity != null && StorageHelpers.getItemCapFromTile(world, tileEntity) != null) {
                 containers.add(tileEntity);
             }
         }


### PR DESCRIPTION
Update the Insert glyph to use IItemHandler capability detection instead of Container instances.

Previously, the `EffectInsert` glyph only interacted with blocks implementing `Container`. This change updates `getContainersInArea` to check for `IItemHandler` capability, making the glyph compatible with a wider range of blocks that expose item handling capabilities and ensuring consistency with other parts of the `EffectInsert` class that already utilize `IItemHandler`.

---
<a href="https://cursor.com/background-agent?bcId=bc-45dd2c17-9748-4caa-87d3-8602d051d206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45dd2c17-9748-4caa-87d3-8602d051d206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

